### PR TITLE
Add --simplify option to bin/messageformat

### DIFF
--- a/bin/messageformat.js
+++ b/bin/messageformat.js
@@ -32,7 +32,7 @@ if (options.help || inputFiles.length === 0) {
 } else {
   var locale = options.locale ? options.locale.join(',').split(/[ ,]+/) : null;
   if (inputFiles.length === 0) inputFiles = [ process.cwd() ];
-  var input = readInput(inputFiles, '.json', '/');
+  var input = readInput(inputFiles, '.json', path.sep);
   var ns = options.namespace || 'module.exports';
   var mf = new MessageFormat(locale);
   if (options['disable-plural-key-checks']) mf.disablePluralKeyChecks();

--- a/bin/messageformat.js
+++ b/bin/messageformat.js
@@ -76,13 +76,6 @@ function printUsage() {
 
 
 function readInput(include, ext, sep) {
-  // modified from http://stackoverflow.com/a/1917041
-  function sharedPathLength(array) {
-    var A = array.sort(), a1 = A[0], a2 = A[A.length - 1], len = a1.length, i = 0;
-    while (i < len && a1.charAt(i) === a2.charAt(i)) ++i;
-    return a1.substring(0, i).replace(/[^/]+$/, '').length;
-  }
-
   var ls = [];
   include.forEach(function(fn) {
     if (!fs.existsSync(fn)) throw new Error('Input file not found: ' + fn);
@@ -94,12 +87,9 @@ function readInput(include, ext, sep) {
     }
   });
 
-  var start = sharedPathLength(ls);
-  var end = -1 * ext.length;
   var input = {};
   ls.forEach(function(fn) {
-    var key = fn.slice(start, end);
-    var parts = key.split(sep);
+    var parts = fn.slice(0, -ext.length).split(sep);
     var last = parts.length - 1;
     parts.reduce(function(root, part, idx) {
       if (idx == last) root[part] = require(fn);
@@ -107,5 +97,10 @@ function readInput(include, ext, sep) {
       return root[part];
     }, input);
   });
+  while (true) {
+      var keys = Object.keys(input);
+      if (keys.length === 1) input = input[keys[0]];
+      else break;
+  }
   return input;
 }


### PR DESCRIPTION
See #165 for the discussion leading to this. This PR adds a `--simplify` command-line parameter to `bin/messageformat.js`:

```
-s, --simplify
      Simplify the output object structure, by dropping intermediate keys when
      those keys are shared across all objects at that level, in addition to
      the default filtering-out of shared keys at the root of the object.
      [default: false]
```

Sorry, this has been sitting on my private branch for ages now, completely forgot that it probably ought to be merged into upstream as well...