### PR TITLE
Don't require `other` in plurals when plural functions have been set manually

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
   - "node"
-  - "iojs"
-  - "0.12"
-  - "0.10"
+  - "6"
+  - "4"

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -8,7 +8,7 @@ var parse = require('messageformat-parser').parse;
  * @param {MessageFormat} mf - A MessageFormat instance
  * @property {object} locales - The locale identifiers that are used by the compiled functions
  * @property {object} runtime - Names of the core runtime functions that are used by the compiled functions
- * @property {object} formatters - The formatter functions that are used by the compiled functions 
+ * @property {object} formatters - The formatter functions that are used by the compiled functions
  */
 function Compiler(mf) {
     this.mf = mf;
@@ -69,7 +69,7 @@ Compiler.bidiMarkText = function(text, locale) {
 
 /** @private */
 Compiler.prototype.cases = function(token, plural) {
-  var needOther = true;
+  var needOther = token.type === 'select' || !this.mf.hasCustomPluralFuncs;
   var r = token.cases.map(function(c) {
     if (c.key === 'other') needOther = false;
     var s = c.tokens.map(function(tok) { return this.token(tok, plural); }, this);

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,6 +63,7 @@ function MessageFormat(locale) {
         if (typeof locale[lc] != 'function') throw new Error('Expected function value for locale ' + JSON.stringify(lc));
         this.pluralFuncs[lc] = locale[lc];
       }
+      this.hasCustomPluralFuncs = true;
     }
   }
   this.fmt = {};

--- a/test/messageformat.js
+++ b/test/messageformat.js
@@ -172,6 +172,14 @@ describe("Basic Message Formatting", function() {
     expect(function(){ var x = mf.compile("{X, selectordinal, someoption{a}}"); }).to.throwError();
   });
 
+  it("does not throw an error when no `other` option is found - plurals with custom pluralFunc", function() {
+    var fake = function(x, ord) { return ord ? 'few' : 'some'; }
+    fake.cardinal = ['some']
+    fake.ordinal = ['few']
+    var mf = new MessageFormat({ fake: fake });
+    expect(function(){ var x = mf.compile("{X, plural, some{a}}"); }).to.not.throwError();
+  });
+
   it("only calculates the offset from non-literals", function() {
     var mf = new MessageFormat('en');
     var mfunc = mf.compile("{NUM, plural, offset:1 =0{a} one{b} other{c}}");


### PR DESCRIPTION
According to the spec, all `plural`, `select`, and `selectordinal` instances should include an `other` case as a fallback. If, however, messageformat has been initialised with a custom pluralisation function (i.e. with `new MessageFormat({ [lc]: function })`), that function (and therefore the string being parsed) may use a different set of pluralisation categories than the standard zero/one/two/few/many/other. Therefore in that case we should trust that the user knows what they're doing, and not complain about the missing key.

This is relevant to my interests as I'm working on [gettext-to-messageformat](/eemeli/gettext-to-messageformat), and gettext uses language-specific integers for pluralisation categories, along with  an inline-provided pluralisation function.