### PR TITLE
Update Travis CI config: Drop v0.10, v0.12 & iojs, add v4 & v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
   - "node"
-  - "iojs"
-  - "0.12"
-  - "0.10"
+  - "6"
+  - "4"


### PR DESCRIPTION
As I mentioned [here](/messageformat/messageformat.js/issues/173#issuecomment-345417791):
> Our API docs are being built by jsdoc, which needed to get updated to work with node 8.5 because of jsdoc3/jsdoc#1438, but on the other hand that's now depending on babel 7.0, which dropped support for node 0.12 with babel/babel#4315.

So we need to update at least our Travis CI config in order to get any CI tests to pass. Node v4 is the oldest which should work fine; Node v6 currently has the highest number of users.