### PR TITLE
Add runtime accessor class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CHK=${GREEN} ✓${STOP}
 ERR=${RED} ✖${STOP}
 
 BIN=./node_modules/.bin
-SRC=lib/index.js lib/compiler.js lib/formatters/* lib/runtime.js
+SRC=lib/index.js lib/compiler.js lib/formatters/* lib/get.js lib/runtime.js
 
 .PHONY: all test test-browser doc release clean
 

--- a/lib/get.js
+++ b/lib/get.js
@@ -49,8 +49,14 @@
  * messages.get('c').d({ P: 0.628 })       // 'We have 63% code coverage.'
  */
 function Get(locales, defaultLocale) {
-  this._data = locales || {};
-  this._fallback = {}
+  this._data = {};
+  this._fallback = {};
+  Object.keys(locales).forEach(function(lc) {
+    if (lc !== 'toString') {
+      this._data[lc] = locales[lc];
+      if (typeof defaultLocale === 'undefined') defaultLocale = lc;
+    }
+  }, this);
 
   /**
    * List of available locales
@@ -65,7 +71,7 @@ function Get(locales, defaultLocale) {
    * Current locale
    * @member {string}
    */
-  this.locale = typeof defaultLocale !== 'undefined' ? defaultLocale : this.availableLocales[0];
+  this.locale = defaultLocale;
 
   /**
    * Default fallback locale
@@ -83,7 +89,10 @@ module.exports = Get;
  * @returns {Get} The Get instance, to allow for chaining
  */
 Get.prototype.addLocale = function(lc, data) {
-  this._data[lc] = data;
+  this._data[lc] = Object.keys(data).reduce(function(map, key) {
+    if (key !== 'toString') map[key] = data[key];
+    return map
+  }, {});
   return this;
 }
 

--- a/lib/get.js
+++ b/lib/get.js
@@ -1,0 +1,204 @@
+/**
+ * Accessor for compiled MessageFormat functions
+ *
+ * @class
+ * @param {object} locales A map of locale codes to their function objects
+ * @param {string|null} [defaultLocale] If not defined, default and initial locale is the first entry of `locales`
+ *
+ * @example
+ * var fs = require('fs');
+ * var MessageFormat = require('messageformat');
+ * var mf = new MessageFormat(['en', 'fi']);
+ * var msgSet = {
+ *   en: {
+ *     a: 'A {TYPE} example.',
+ *     b: 'This has {COUNT, plural, one{one user} other{# users}}.',
+ *     c: {
+ *       d: 'We have {P, number, percent} code coverage.'
+ *     }
+ *   },
+ *   fi: {
+ *     b: 'Tällä on {COUNT, plural, one{yksi käyttäjä} other{# käyttäjää}}.',
+ *     e: 'Minä puhun vain suomea.'
+ *   }
+ * };
+ * var cfStr = mf.compile(msgSet).toString('module.exports');
+ * fs.writeFileSync('messages.js', cfStr);
+ *
+ * ...
+ *
+ * var MessageFormatGet = require('messageformat/lib/get');
+ * var msgData = require('./messages');
+ * var messages = new MessageFormatGet(msgData, 'en');
+ *
+ * messages.hasMessage('a')                // true
+ * messages.hasObject('c')                 // true
+ * messages.get('b', { COUNT: 3 })         // 'This has 3 users.'
+ * messages.get(['c', 'd'], { P: 0.314 })  // 'We have 31% code coverage.'
+ *
+ * messages.get('e')                       // 'e'
+ * messages.setFallback('en', ['foo', 'fi'])
+ * messages.get('e')                       // 'Minä puhun vain suomea.'
+ *
+ * messages.locale = 'fi'
+ * messages.hasMessage('a')                // false
+ * messages.hasMessage('a', 'en')          // true
+ * messages.hasMessage('a', null, true)    // true
+ * messages.hasObject('c')                 // false
+ * messages.get('b', { COUNT: 3 })         // 'Tällä on 3 käyttäjää.'
+ * messages.get('c').d({ P: 0.628 })       // 'We have 63% code coverage.'
+ */
+function Get(locales, defaultLocale) {
+  this._data = locales || {};
+  this._fallback = {}
+
+  /**
+   * List of available locales
+   * @readonly
+   * @member {string[]} availableLocales
+   */
+  Object.defineProperty(this, 'availableLocales', {
+    get() { return Object.keys(this._data) }
+  });
+
+  /**
+   * Current locale
+   * @member {string}
+   */
+  this.locale = typeof defaultLocale !== 'undefined' ? defaultLocale : this.availableLocales[0];
+
+  /**
+   * Default fallback locale
+   * @member {string|null}
+   */
+  this.defaultLocale = this.locale;
+}
+
+module.exports = Get;
+
+/**
+ * Add a new locale to the accessor; useful if loading locales dynamically
+ * @param {string} lc Locale identifier
+ * @param {object} data Hierarchical map of keys to functions
+ * @returns {Get} The Get instance, to allow for chaining
+ */
+Get.prototype.addLocale = function(lc, data) {
+  this._data[lc] = data;
+  return this;
+}
+
+/**
+ * Get the list of fallback locales
+ * @param {string} [lc] If empty or undefined, defaults to `this.locale`
+ * @returns {string[]}
+ */
+Get.prototype.getFallback = function(lc) {
+  if (!lc) lc = this.locale;
+  return this._fallback[lc] || (
+    lc === this.defaultLocale || !this.defaultLocale ? [] : [this.defaultLocale]
+  );
+}
+
+/**
+ * Set the fallback locale or locales for `lc`
+ *
+ * To disable fallback for the locale, use `setFallback(lc, [])`.
+ * To use the default fallback, use `setFallback(lc, null)`.
+ *
+ * @param {string} lc
+ * @param {string[]|null} fallback
+ * @returns {Get} The Get instance, to allow for chaining
+ */
+Get.prototype.setFallback = function(lc, fallback) {
+  this._fallback[lc] = Array.isArray(fallback) ? fallback : null;
+  return this;
+}
+
+/** @private */
+function _get(obj, key) {
+  if (!obj) return null;
+  if (Array.isArray(key)) {
+    for (var i = 0; i < key.length; ++i) {
+      obj = obj[key[i]];
+      if (!obj) return null;
+    }
+    return obj;
+  }
+  return obj[key];
+}
+
+/** @private */
+function _has(data, lc, key, fallback, type) {
+  var msg = _get(data[lc], key);
+  if (msg) return typeof msg === type;
+  if (fallback) {
+    for (var i = 0; i < fallback.length; ++i) {
+      msg = _get(data[fallback[i]], key);
+      if (msg) return typeof msg === type;
+    }
+  }
+  return false;
+}
+
+/**
+ * Check if `key` is a message function for the locale
+ *
+ * `key` may be a `string` for functions at the root level, or `string[]` for
+ * accessing hierarchical objects. If an exact match is not found and `fallback`
+ * is true, the fallback locales are checked for the first match.
+ *
+ * @param {string|string[]} key The key or keypath being sought
+ * @param {string} [lc] If empty or undefined, defaults to `this.locale`
+ * @param {boolean} [fallback=false] If true, also checks fallback locales
+ * @returns {boolean}
+ */
+Get.prototype.hasMessage = function(key, lc, fallback) {
+  if (!lc) lc = this.locale;
+  var fb = fallback ? this.getFallback(lc) : null;
+  return _has(this._data, lc, key, fb, 'function');
+}
+
+/**
+ * Check if `key` is a message object for the locale
+ *
+ * `key` may be a `string` for functions at the root level, or `string[]` for
+ * accessing hierarchical objects. If an exact match is not found and `fallback`
+ * is true, the fallback locales are checked for the first match.
+ *
+ * @param {string|string[]} key The key or keypath being sought
+ * @param {string} [lc] If empty or undefined, defaults to `this.locale`
+ * @param {boolean} [fallback=false] If true, also checks fallback locales
+ * @returns {boolean}
+ */
+Get.prototype.hasObject = function(key, lc, fallback) {
+  if (!lc) lc = this.locale;
+  var fb = fallback ? this.getFallback(lc) : null;
+  return _has(this._data, lc, key, fb, 'object');
+}
+
+/**
+ * Get the message or object corresponding to `key`
+ *
+ * `key` may be a `string` for functions at the root level, or `string[]` for
+ * accessing hierarchical objects. If an exact match is not found, the fallback
+ * locales are checked for the first match.
+ *
+ * If `key` maps to a message function, it will be called with `props`. If it
+ * maps to an object, the object is returned directly.
+ *
+ * @param {string|string[]} key The key or keypath being sought
+ * @param {object} [props] Optional properties passed to the function
+ * @param {string} [lc] If empty or undefined, defaults to `this.locale`
+ * @returns {string|Object<string,function|object>}
+ */
+Get.prototype.get = function(key, props, lc) {
+  if (!lc) lc = this.locale;
+  var msg = _get(this._data[lc], key);
+  if (msg) return typeof msg == 'function' ? msg(props) : msg;
+  var fb = this.getFallback(lc);
+  for (var i = 0; i < fb.length; ++i) {
+    msg = _get(this._data[fb[i]], key);
+    if (msg) return typeof msg == 'function' ? msg(props) : msg;
+  }
+  return key;
+}

--- a/test/get.js
+++ b/test/get.js
@@ -1,0 +1,106 @@
+if (typeof require !== 'undefined') {
+  var expect = require('expect.js');
+  var Get = require('../lib/get');
+  var MessageFormat = require('../');
+}
+
+describe('Get', () => {
+  let msgData, messages;
+
+  before(() => {
+    const mf = new MessageFormat(['en', 'fi']);
+    const msgSet = {
+      en: {
+        a: 'A {TYPE} example.',
+        b: 'This has {COUNT, plural, one{one user} other{# users}}.',
+        c: {
+          d: 'We have {P, number, percent} code coverage.'
+        }
+      },
+      fi: {
+        b: 'Tällä on {COUNT, plural, one{yksi käyttäjä} other{# käyttäjää}}.',
+        e: 'Minä puhun vain suomea.'
+      }
+    };
+    msgData = mf.compile(msgSet);
+  })
+
+  beforeEach(() => {
+    messages = new Get(msgData, 'en');
+  })
+
+  it('constructor', () => {
+    expect(messages).to.be.a(Get);
+    expect(messages.locale).to.eql('en');
+    expect(messages.defaultLocale).to.eql('en');
+    expect(messages.availableLocales).to.eql(['en', 'fi']);
+    messages = new Get(msgData);
+    expect(messages.locale).to.eql('en');
+    messages = new Get(msgData, 'fi');
+    expect(messages.locale).to.eql('fi');
+    messages = new Get(msgData, null);
+    expect(messages.locale).to.eql(null);
+  });
+
+  it('hasMessage', () => {
+    expect(messages.hasMessage('a')).to.be(true);
+    expect(messages.hasMessage('c')).to.be(false);
+    messages.locale = 'fi';
+    expect(messages.hasMessage('a')).to.be(false);
+    expect(messages.hasMessage('a', 'en')).to.be(true);
+    expect(messages.hasMessage('a', null, true)).to.be(true);
+  });
+
+  it('hasObject', () => {
+    expect(messages.hasObject('a')).to.be(false);
+    expect(messages.hasObject('c')).to.be(true);
+    messages.locale = 'fi';
+    expect(messages.hasObject('c')).to.be(false);
+    expect(messages.hasObject('c', 'en')).to.be(true);
+    expect(messages.hasObject('c', null, true)).to.be(true);
+  });
+
+  it('get/set fallback', () => {
+    expect(messages.getFallback()).to.eql([]);
+    expect(messages.getFallback('fi')).to.eql(['en']);
+    messages.setFallback('en', ['foo', 'fi']);
+    expect(messages.getFallback()).to.eql(['foo', 'fi']);
+    messages.locale = 'fi';
+    expect(messages.getFallback()).to.eql(['en']);
+    messages.setFallback('fi', []);
+    expect(messages.getFallback()).to.eql([]);
+    messages.setFallback('fi', null);
+    expect(messages.getFallback()).to.eql(['en']);
+    messages.defaultLocale = null;
+    expect(messages.getFallback()).to.eql([]);
+  });
+
+  it('get message', () => {
+    expect(messages.get('b', { COUNT: 3 })).to.eql('This has 3 users.');
+    expect(messages.get(['c', 'd'], { P: 0.314 })).to.eql('We have 31% code coverage.');
+    expect(messages.get('e')).to.eql('e');
+    messages.setFallback('en', ['foo', 'fi']);
+    expect(messages.get('e')).to.eql('Minä puhun vain suomea.');
+    messages.locale = 'fi';
+    expect(messages.get('b', { COUNT: 3 })).to.eql('Tällä on 3 käyttäjää.');
+  });
+
+  it('get object', () => {
+    expect(messages.get('c')).to.have.property('d')
+    messages.locale = 'fi';
+    expect(messages.get('c')).to.have.property('d')
+    expect(messages.get('c').d({ P: 0.628 })).to.eql('We have 63% code coverage.');
+    expect(messages.get([])).to.only.have.keys(['b', 'e']);
+  });
+
+  it('addLocale', () => {
+    const mf = new MessageFormat('sv');
+    const sv = { e: 'Jag pratar lite svenska.' }
+    messages.addLocale('sv', mf.compile(sv));
+    expect(messages.availableLocales).to.eql(['en', 'fi', 'sv']);
+    messages.locale = 'sv'
+    expect(messages.get('e')).to.eql('Jag pratar lite svenska.');
+    expect(messages.getFallback()).to.eql(['en']);
+    expect(messages.get([])).to.only.have.key('e');
+  });
+});


### PR DESCRIPTION
Re: #187, possibly some other issues as well.

This adds `lib/get.js`, a runtime accessor class for compiled MessageFormat objects. It's a new API, so the method and other names can and should be changed if we think of something else that's better. Here's how it would work:

First, presuming that we have the messages in a JSON file `messages.json`:
```json
{
  "en": {
    "a": "A {TYPE} example.",
    "b": "This has {COUNT, plural, one{one user} other{# users}}.",
    "c": {
      "d": "We have {P, number, percent} code coverage."
    }
  },
  "fi": {
    "b": "Tällä on {COUNT, plural, one{yksi käyttäjä} other{# käyttäjää}}.",
    "e": "Minä puhun vain suomea."
  }
}
```

And that we've compiled that into JavaScript:
```
messageformat -l en,fi messages.json > messageData.js
```

Then we can use the new getter and this API:
```js
var MessageFormatGet = require('messageformat/lib/get');
var msgData = require('./messageData');
var messages = new MessageFormatGet(msgData, 'en');

messages.hasMessage('a')                // true
messages.hasObject('c')                 // true
messages.get('b', { COUNT: 3 })         // 'This has 3 users.'
messages.get(['c', 'd'], { P: 0.314 })  // 'We have 31% code coverage.'

messages.get('e')                       // 'e'
messages.setFallback('en', ['foo', 'fi'])
messages.get('e')                       // 'Minä puhun vain suomea.'

messages.locale = 'fi'
messages.hasMessage('a')                // false
messages.hasMessage('a', 'en')          // true
messages.hasMessage('a', null, true)    // true
messages.hasObject('c')                 // false
messages.get('b', { COUNT: 3 })         // 'Tällä on 3 käyttäjää.'
messages.get('c').d({ P: 0.628 })       // 'We have 63% code coverage.'
```

Based on how I've used MessageFormat myself and seen it used by others, I believe that the above would provide a more developer-friendly interface, as well as being less likely to throw errors.

The code already has JSDoc comments, but here's an overview of the class's members:

```typescript
constructor (locales: object, defaultLocale: string | null | undefined)

availableLocales: string[]  // readonly
defaultLocale: string | null
locale: string

addLocale (lc: string, data: object)
getFallback (lc: string | undefined): string[]
setFallback (lc: string, fallback: string[] | null)

get (key: string | string[], props: object | undefined, lc: string | undefined): string | object
hasMessage (key: string | string[], lc: string | undefined, fallback: boolean | undefined): boolean
hasObject (key: string | string[], lc: string | undefined, fallback: boolean | undefined): boolean
```

For getters, `this.locale` is used if `lc` is null or undefined. `key` can be a string for top-level objects, or a keypath for hierarchical objects.